### PR TITLE
Update download_modelnet40_data to download from url parameter

### DIFF
--- a/bps_demos/modelnet40.py
+++ b/bps_demos/modelnet40.py
@@ -35,8 +35,7 @@ def download_modelnet40_data(url, root_data_dir):
     download_path = os.path.join(root_data_dir, 'modelnet40_ply_hdf5_2048.zip')
 
     print("downloading ModelNet40 data..")
-    modelnet40_url = 'https://shapenet.cs.stanford.edu/media/modelnet40_ply_hdf5_2048.zip'
-    urllib.request.urlretrieve(modelnet40_url, download_path, _download_reporthook)
+    urllib.request.urlretrieve(url, download_path, _download_reporthook)
 
     print('unzipping files..')
     _unzip_data(download_path, root_data_dir)


### PR DESCRIPTION
The function 'download_modelnet40_data' takes url as a parameter but never uses it; at line 38 'modelnet40_url = 'https://shapenet.cs.stanford.edu/media/modelnet40_ply_hdf5_2048.zip'' is defined, and that URL is used instead of the passed in URL. This change uses the passed in url.